### PR TITLE
Ignore non-ascii characters.

### DIFF
--- a/autoload/padawan.vim
+++ b/autoload/padawan.vim
@@ -85,10 +85,10 @@ else:
     completions = client.GetCompletion(filepath, line, column, contents)
     completions = [
         {
-        'word': completion["name"].encode("ascii") if completion["name"] else '',
-        'abbr': completion["menu"].encode("ascii") if completion["menu"] else '',
-        'info': completion["description"].encode("ascii") if completion["description"] else '',
-        'menu': completion["signature"].encode('ascii') if completion["signature"] else ''
+        'word': completion["name"].encode("ascii", 'ignore') if completion["name"] else '',
+        'abbr': completion["menu"].encode("ascii", 'ignore') if completion["menu"] else '',
+        'info': completion["description"].encode("ascii", 'ignore') if completion["description"] else '',
+        'menu': completion["signature"].encode('ascii', 'ignore') if completion["signature"] else ''
         }
         for completion in completions["completion"]
     ]


### PR DESCRIPTION
Instead of failing (and breaking completion), characters outside of the
ascii encoding will be silently ignored.
